### PR TITLE
Add support for scanning strings, numbers, and comments

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -12,11 +12,6 @@
     <property name="max" value="120"/>
     <property name="ignorePattern" value="^package.*|^import.*|^\s*\*.*"/>
   </module>
-  <!-- Separate check for comment length (80 characters) -->
-  <module name="RegexpSingleline">
-    <property name="format" value="^\s*(/\*\*?|\*|//).{79,}"/>
-    <property name="message" value="Comment line is longer than 80 characters"/>
-  </module>
   <!-- Files must end with newline -->
   <module name="NewlineAtEndOfFile"/>
   <!-- No trailing spaces -->

--- a/src/main/java/com/andreychh/lox/lexing/state/InitialState.java
+++ b/src/main/java/com/andreychh/lox/lexing/state/InitialState.java
@@ -57,6 +57,7 @@ public final class InitialState implements LexingState {
             case '!', '=', '>', '<' -> new CompoundOperatorState(this.source, this.result);
             case '/' -> new SlashState(this.source, this.result);
             case '"' -> new StringState(this.source, this.result);
+            case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9' -> new NumberState(this.source, this.result);
             default -> {
                 Error error = new Error("Unexpected character '%s'.".formatted(character), this.source.position());
                 yield new InitialState(this.source.skip(1), this.result.withError(error));

--- a/src/main/java/com/andreychh/lox/lexing/state/InitialState.java
+++ b/src/main/java/com/andreychh/lox/lexing/state/InitialState.java
@@ -10,10 +10,8 @@ import com.andreychh.lox.token.TokenFromLexeme;
 /**
  * The initial state of the lexical analysis process.
  * <p>
- * This state is responsible for examining the next character in the source
- * and transitioning to the appropriate specialized state based on the
- * character.
- * It directly handles simple single-character tokens and whitespace.
+ * This state is responsible for examining the next character in the source and transitioning to the appropriate
+ * specialized state based on the character. It directly handles simple single-character tokens and whitespace.
  */
 public final class InitialState implements LexingState {
     private final Source source;
@@ -42,8 +40,7 @@ public final class InitialState implements LexingState {
     /**
      * {@inheritDoc}
      * <p>
-     * Examines the next character and transitions to the appropriate state or
-     * directly handles simple tokens.
+     * Examines the next character and transitions to the appropriate state or directly handles simple tokens.
      */
     @Override
     public LexingStep next() {
@@ -58,6 +55,7 @@ public final class InitialState implements LexingState {
                 yield new InitialState(this.source.skip(1), this.result.withToken(token));
             }
             case '!', '=', '>', '<' -> new CompoundOperatorState(this.source, this.result);
+            case '/' -> new SlashState(this.source, this.result);
             default -> {
                 Error error = new Error("Unexpected character '%s'.".formatted(character), this.source.position());
                 yield new InitialState(this.source.skip(1), this.result.withError(error));

--- a/src/main/java/com/andreychh/lox/lexing/state/InitialState.java
+++ b/src/main/java/com/andreychh/lox/lexing/state/InitialState.java
@@ -56,6 +56,7 @@ public final class InitialState implements LexingState {
             }
             case '!', '=', '>', '<' -> new CompoundOperatorState(this.source, this.result);
             case '/' -> new SlashState(this.source, this.result);
+            case '"' -> new StringState(this.source, this.result);
             default -> {
                 Error error = new Error("Unexpected character '%s'.".formatted(character), this.source.position());
                 yield new InitialState(this.source.skip(1), this.result.withError(error));

--- a/src/main/java/com/andreychh/lox/lexing/state/NumberState.java
+++ b/src/main/java/com/andreychh/lox/lexing/state/NumberState.java
@@ -1,0 +1,85 @@
+package com.andreychh.lox.lexing.state;
+
+import com.andreychh.lox.Source;
+import com.andreychh.lox.lexing.LexingResult;
+import com.andreychh.lox.lexing.LexingStep;
+import com.andreychh.lox.token.ExplicitToken;
+import com.andreychh.lox.token.TokenType;
+
+/**
+ * A lexing state for processing numeric literals.
+ * <p>
+ * This state is entered when a digit character is encountered in the source code.
+ * <p>
+ * {@snippet :
+ * // Creates a number token for "123"
+ * NumberState state = new NumberState(new Source("123"), new LexingResult());
+ * LexingStep step = state.next(); // Returns number token
+ *
+ * // Creates a number token for "123.45"
+ * NumberState decimalState = new NumberState(new Source("123.45"), new LexingResult());
+ * LexingStep decimalStep = decimalState.next(); // Returns number token
+ *
+ * // Creates a number token for "42.0"
+ * NumberState zeroDecimalState = new NumberState(new Source("42.0"), new LexingResult());
+ * LexingStep zeroStep = zeroDecimalState.next(); // Returns number token
+ *}
+ */
+public final class NumberState implements LexingState {
+    private final Source source;
+    private final LexingResult result;
+
+    /**
+     * Creates a new number state with the given source and accumulated result.
+     *
+     * @param source The source code positioned at a numeric literal
+     * @param result The accumulated lexing result
+     */
+    public NumberState(final Source source, final LexingResult result) {
+        this.source = source;
+        this.result = result;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Processes the numeric literal by consuming consecutive digit characters. If a decimal point is encountered
+     * followed by at least one digit, continues consuming digits to form a decimal number. Creates a NUMBER token with
+     * the complete numeric lexeme.
+     */
+    @Override
+    public LexingStep next() {
+        Source curr = this.source;
+        StringBuilder lexeme = new StringBuilder();
+        while (curr.canPeek(0) && Character.isDigit(curr.peek(0))) {
+            lexeme.append(curr.peek(0));
+            curr = curr.skip(1);
+        }
+        if (curr.canPeek(0) && curr.peek(0) == '.'
+                && curr.canPeek(1) && Character.isDigit(curr.peek(1))) {
+            lexeme.append('.');
+            curr = curr.skip(1);
+            while (curr.canPeek(0) && Character.isDigit(curr.peek(0))) {
+                lexeme.append(curr.peek(0));
+                curr = curr.skip(1);
+            }
+        }
+        return new LexingStep(
+                new InitialState(
+                        curr,
+                        this.result.withToken(
+                                new ExplicitToken(TokenType.NUMBER, lexeme.toString(), this.source.position())
+                        )
+                ),
+                false
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public LexingResult collectResult() {
+        return this.result;
+    }
+}

--- a/src/main/java/com/andreychh/lox/lexing/state/SlashState.java
+++ b/src/main/java/com/andreychh/lox/lexing/state/SlashState.java
@@ -1,0 +1,72 @@
+package com.andreychh.lox.lexing.state;
+
+import com.andreychh.lox.Source;
+import com.andreychh.lox.lexing.LexingResult;
+import com.andreychh.lox.lexing.LexingStep;
+import com.andreychh.lox.token.TokenFromLexeme;
+
+/**
+ * A lexing state for handling slash characters and line comments.
+ * <p>
+ * This state is entered when a '/' character is encountered in the source code.
+ * <p>
+ * {@snippet :
+ * // Creates a division token for "/"
+ * SlashState state = new SlashState(new Source("/"), new LexingResult());
+ * LexingStep step = state.next(); // Returns division token
+ *
+ * // Skips line comment for "//"
+ * SlashState commentState = new SlashState(new Source("//comment"), new LexingResult());
+ * LexingStep commentStep = commentState.next(); // Skips comment, no token created
+ *}
+ */
+public final class SlashState implements LexingState {
+    private final Source source;
+    private final LexingResult result;
+
+    /**
+     * Creates a new slash state with the given source and accumulated result.
+     *
+     * @param source The source code positioned at a slash character
+     * @param result The accumulated lexing result
+     */
+    public SlashState(final Source source, final LexingResult result) {
+        this.source = source;
+        this.result = result;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Processes the slash character by examining the following character. If followed by another slash, skips the line
+     * comment until a newline character. Otherwise, creates a division operator token and transitions back to the
+     * initial state.
+     */
+    @Override
+    public LexingStep next() {
+        if (this.source.canPeek(1) && this.source.peek(1) == '/') {
+            return new LexingStep(
+                    new InitialState(
+                            this.source.skip(2).skipWhile(c -> c != '\n'),
+                            this.result
+                    ),
+                    false
+            );
+        }
+        return new LexingStep(
+                new InitialState(
+                        this.source.skip(1),
+                        this.result.withToken(new TokenFromLexeme("/", this.source.position()))
+                ),
+                false
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public LexingResult collectResult() {
+        return this.result;
+    }
+}

--- a/src/main/java/com/andreychh/lox/lexing/state/StringState.java
+++ b/src/main/java/com/andreychh/lox/lexing/state/StringState.java
@@ -1,0 +1,67 @@
+package com.andreychh.lox.lexing.state;
+
+import com.andreychh.lox.Error;
+import com.andreychh.lox.Source;
+import com.andreychh.lox.lexing.LexingResult;
+import com.andreychh.lox.lexing.LexingStep;
+import com.andreychh.lox.token.ExplicitToken;
+import com.andreychh.lox.token.Token;
+import com.andreychh.lox.token.TokenType;
+
+/**
+ * A lexing state for processing string literals.
+ * <p>
+ * This state is entered when a '"' character is encountered in the source code.
+ * <p>
+ * {@snippet :
+ * // Creates a string token for "\"hello\""
+ * StringState state = new StringState(new Source("\"hello\""), new LexingResult());
+ * LexingStep step = state.next(); // Returns string token
+ *
+ * // Handles unterminated string
+ * StringState unterminatedState = new StringState(new Source("\"hello"), new LexingResult());
+ * LexingStep errorStep = unterminatedState.next(); // Returns error for unterminated string
+ *}
+ */
+public final class StringState implements LexingState {
+    private final Source source;
+    private final LexingResult result;
+
+    /**
+     * Creates a new string state with the given source and accumulated result.
+     *
+     * @param source The source code positioned at a string literal
+     * @param result The accumulated lexing result
+     */
+    public StringState(final Source source, final LexingResult result) {
+        this.source = source;
+        this.result = result;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Processes the string literal by consuming characters until the closing quote is found. If the string is not
+     * properly terminated, generates an error. The resulting token includes the quote characters in the lexeme.
+     */
+    @Override
+    public LexingStep next() {
+        String lexeme = "\"%s\"".formatted(this.source.skip(1).takeWhile(c -> c != '"'));
+        Source source = this.source.skip(1).skipWhile(c -> c != '"');
+        if (!source.canPeek(0)) {
+            Error error = new Error("Unterminated string literal", this.source.position());
+            return new LexingStep(new EOFState(source, this.result.withError(error)), false);
+        }
+        Token token = new ExplicitToken(TokenType.STRING, lexeme, this.source.position());
+        LexingState state = new InitialState(source.skip(1), this.result.withToken(token));
+        return new LexingStep(state, false);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public LexingResult collectResult() {
+        return this.result;
+    }
+}

--- a/src/test/java/com/andreychh/lox/lexing/state/NumberStateTest.java
+++ b/src/test/java/com/andreychh/lox/lexing/state/NumberStateTest.java
@@ -1,0 +1,105 @@
+package com.andreychh.lox.lexing.state;
+
+import com.andreychh.lox.Position;
+import com.andreychh.lox.Source;
+import com.andreychh.lox.lexing.LexingResult;
+import com.andreychh.lox.token.ExplicitToken;
+import com.andreychh.lox.token.TokenType;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests for {@link NumberState}.
+ */
+class NumberStateTest {
+    @Test
+    void createsNumberTokenFromIntegerLiteral() {
+        assertEquals(
+                new ExplicitToken(TokenType.NUMBER, "42", new Position(1, 1)),
+                new NumberState(new Source("42"), new LexingResult())
+                        .next()
+                        .state()
+                        .collectResult()
+                        .tokens()
+                        .iterator()
+                        .next(),
+                "NumberState does not create number token from integer literal"
+        );
+    }
+
+    @Test
+    void preservesZeroPaddedFloatLiteral() {
+        assertEquals(
+                new ExplicitToken(TokenType.NUMBER, "042.000", new Position(1, 1)),
+                new NumberState(new Source("042.000"), new LexingResult())
+                        .next()
+                        .state()
+                        .collectResult()
+                        .tokens()
+                        .iterator()
+                        .next(),
+                "NumberState incorrectly simplifies the lexeme instead of preserving 042.000"
+        );
+    }
+
+    @Test
+    void createsNumberTokenFromFloatLiteral() {
+        assertEquals(
+                new ExplicitToken(TokenType.NUMBER, "42.0", new Position(1, 1)),
+                new NumberState(new Source("42.0"), new LexingResult())
+                        .next()
+                        .state()
+                        .collectResult()
+                        .tokens()
+                        .iterator()
+                        .next(),
+                "NumberState does not create number token from float literal"
+        );
+    }
+
+    @Test
+    void createsNumberTokenFromIntegerWithTrailingDot() {
+        assertEquals(
+                new ExplicitToken(TokenType.NUMBER, "42", new Position(1, 1)),
+                new NumberState(new Source("42."), new LexingResult())
+                        .next()
+                        .state()
+                        .collectResult()
+                        .tokens()
+                        .iterator()
+                        .next(),
+                "NumberState does not create number token from integer with trailing dot"
+        );
+    }
+
+    @Test
+    void createsNumberTokenFromMultipleDots() {
+        assertEquals(
+                new ExplicitToken(TokenType.NUMBER, "1.2", new Position(1, 1)),
+                new NumberState(new Source("1.2.3"), new LexingResult())
+                        .next()
+                        .state()
+                        .collectResult()
+                        .tokens()
+                        .iterator()
+                        .next(),
+                "NumberState does not create number token from input with multiple dots"
+        );
+    }
+
+    @Test
+    void createsNumberTokenFromDoubleDots() {
+        assertEquals(
+                new ExplicitToken(TokenType.NUMBER, "1", new Position(1, 1)),
+                new NumberState(new Source("1..2.3"), new LexingResult())
+                        .next()
+                        .state()
+                        .collectResult()
+                        .tokens()
+                        .iterator()
+                        .next(),
+                "NumberState does not create number token from input with double dots"
+        );
+    }
+}

--- a/src/test/java/com/andreychh/lox/lexing/state/SlashStateTest.java
+++ b/src/test/java/com/andreychh/lox/lexing/state/SlashStateTest.java
@@ -1,0 +1,101 @@
+package com.andreychh.lox.lexing.state;
+
+import com.andreychh.lox.Position;
+import com.andreychh.lox.Source;
+import com.andreychh.lox.lexing.LexingResult;
+import com.andreychh.lox.token.TokenFromLexeme;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Tests for {@link SlashState}.
+ */
+class SlashStateTest {
+    @Test
+    void createsSlashTokenWhenFollowedBySpace() {
+        assertEquals(
+                new TokenFromLexeme("/", new Position(1, 1)),
+                new SlashState(new Source("/ "), new LexingResult())
+                        .next()
+                        .state()
+                        .collectResult()
+                        .tokens()
+                        .iterator()
+                        .next(),
+                "SlashState failed to create slash token when followed by space"
+        );
+    }
+
+    @Test
+    void createsSlashTokenWhenAtEndOfSource() {
+        assertEquals(
+                new TokenFromLexeme("/", new Position(1, 1)),
+                new SlashState(new Source("/"), new LexingResult())
+                        .next()
+                        .state()
+                        .collectResult()
+                        .tokens()
+                        .iterator()
+                        .next(),
+                "SlashState failed to create slash token when at end of source"
+        );
+    }
+
+    @Test
+    void skipsCommentWithoutCreatingToken() {
+        assertFalse(
+                new SlashState(new Source("//comment"), new LexingResult())
+                        .next()
+                        .state()
+                        .collectResult()
+                        .tokens()
+                        .iterator()
+                        .hasNext(),
+                "SlashState should not create token when processing line comment"
+        );
+    }
+
+    @Test
+    void skipsCommentUntilNewline() {
+        assertFalse(
+                new SlashState(new Source("//comment\n"), new LexingResult())
+                        .next()
+                        .state()
+                        .collectResult()
+                        .tokens()
+                        .iterator()
+                        .hasNext(),
+                "SlashState should not create token when processing line comment ending with newline"
+        );
+    }
+
+    @Test
+    void handlesDoubleSlashAtEndOfSource() {
+        assertFalse(
+                new SlashState(new Source("//"), new LexingResult())
+                        .next()
+                        .state()
+                        .collectResult()
+                        .tokens()
+                        .iterator()
+                        .hasNext(),
+                "SlashState should not create token for double slash at end of source"
+        );
+    }
+
+    @Test
+    void handlesDoubleSlashFollowedByNewline() {
+        assertFalse(
+                new SlashState(new Source("//\n"), new LexingResult())
+                        .next()
+                        .state()
+                        .collectResult()
+                        .tokens()
+                        .iterator()
+                        .hasNext(),
+                "SlashState should not create token for double slash followed immediately by newline"
+        );
+    }
+}

--- a/src/test/java/com/andreychh/lox/lexing/state/StringStateTest.java
+++ b/src/test/java/com/andreychh/lox/lexing/state/StringStateTest.java
@@ -1,0 +1,90 @@
+package com.andreychh.lox.lexing.state;
+
+import com.andreychh.lox.Position;
+import com.andreychh.lox.Source;
+import com.andreychh.lox.lexing.LexingResult;
+import com.andreychh.lox.token.ExplicitToken;
+import com.andreychh.lox.token.TokenType;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link StringState}.
+ */
+class StringStateTest {
+    @Test
+    void createsStringTokenFromSimpleLiteral() {
+        assertEquals(
+            new ExplicitToken(TokenType.STRING, "\"abc\"", new Position(1, 1)),
+            new StringState(new Source("\"abc\""), new LexingResult())
+                .next()
+                .state()
+                .collectResult()
+                .tokens()
+                .iterator()
+                .next(),
+            "StringState does not create string token from simple literal"
+        );
+    }
+
+    @Test
+    void createsEmptyStringToken() {
+        assertEquals(
+            new ExplicitToken(TokenType.STRING, "\"\"", new Position(1, 1)),
+            new StringState(new Source("\"\""), new LexingResult())
+                .next()
+                .state()
+                .collectResult()
+                .tokens()
+                .iterator()
+                .next(),
+            "StringState does not create empty string token"
+        );
+    }
+
+    @Test
+    void createsStringTokenWithNewlineCharacter() {
+        assertEquals(
+            new ExplicitToken(TokenType.STRING, "\"abc\n\"", new Position(1, 1)),
+            new StringState(new Source("\"abc\n\""), new LexingResult())
+                .next()
+                .state()
+                .collectResult()
+                .tokens()
+                .iterator()
+                .next(),
+            "StringState does not create string token containing newline character"
+        );
+    }
+
+    @Test
+    void generatesErrorForUnterminatedString() {
+        assertTrue(
+            new StringState(new Source("\"abc"), new LexingResult())
+                .next()
+                .state()
+                .collectResult()
+                .errors()
+                .iterator()
+                .hasNext(),
+            "StringState does not generate error for unterminated string literal"
+        );
+    }
+
+    @Test
+    void handlesUnicodeCharactersInString() {
+        assertEquals(
+            new ExplicitToken(TokenType.STRING, "\"你好, мир! \uD83D\uDE80\"", new Position(1, 1)),
+            new StringState(new Source("\"你好, мир! \uD83D\uDE80\""), new LexingResult())
+                .next()
+                .state()
+                .collectResult()
+                .tokens()
+                .iterator()
+                .next(),
+            "StringState does not handle Unicode characters in string literal"
+        );
+    }
+}


### PR DESCRIPTION
This pull request introduces new lexing states for handling numeric literals, string literals, and slash/comments in the lexer, along with unit tests for each new state.

Closes #13 