### PR TITLE
Add support for scanning keywords and identifiers

### DIFF
--- a/src/main/java/com/andreychh/lox/lexing/state/IdentifierState.java
+++ b/src/main/java/com/andreychh/lox/lexing/state/IdentifierState.java
@@ -1,0 +1,110 @@
+package com.andreychh.lox.lexing.state;
+
+import com.andreychh.lox.Source;
+import com.andreychh.lox.lexing.LexingResult;
+import com.andreychh.lox.lexing.LexingStep;
+import com.andreychh.lox.token.ExplicitToken;
+import com.andreychh.lox.token.Token;
+import com.andreychh.lox.token.TokenType;
+
+/**
+ * A lexing state for processing identifiers and keywords.
+ * <p>
+ * {@snippet :
+ * // Creates an identifier token for "variable"
+ * IdentifierState state = new IdentifierState(new Source("variable"), new LexingResult());
+ * LexingStep step = state.next(); // Returns IDENTIFIER token
+ *
+ * // Creates a keyword token for "while"
+ * IdentifierState keywordState = new IdentifierState(new Source("while"), new LexingResult());
+ * LexingStep keywordStep = keywordState.next(); // Returns WHILE token
+ *
+ * // Creates an identifier token for "_private"
+ * IdentifierState underscoreState = new IdentifierState(new Source("_private"), new LexingResult());
+ * LexingStep underscoreStep = underscoreState.next(); // Returns IDENTIFIER token
+ *}
+ *
+ * @implNote This state should only be created when the source is positioned at a letter or underscore character.
+ */
+public final class IdentifierState implements LexingState {
+    private final Source source;
+    private final LexingResult result;
+
+    /**
+     * Creates a new identifier state with the given source and accumulated result.
+     *
+     * @param source The source code positioned at an identifier start character
+     * @param result The accumulated lexing result
+     */
+    public IdentifierState(final Source source, final LexingResult result) {
+        this.source = source;
+        this.result = result;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Processes the identifier by consuming consecutive alphanumeric characters and underscores. Determines whether the
+     * resulting lexeme is a reserved keyword or a regular identifier, then creates the appropriate token type.
+     */
+    @Override
+    public LexingStep next() {
+        return new LexingStep(
+                new InitialState(
+                        this.source.skipWhile(this::isAlphaNumeric),
+                        this.result.withToken(this.tokenFromLexeme(this.source.takeWhile(this::isAlphaNumeric)))
+                ),
+                false
+        );
+    }
+
+    /**
+     * Creates a token from the given lexeme, determining whether it represents a keyword or identifier.
+     *
+     * @param lexeme The identifier lexeme to classify
+     * @return A token with the appropriate type (keyword or identifier)
+     */
+    private Token tokenFromLexeme(final String lexeme) {
+        TokenType type = switch (lexeme) {
+            case "and" -> TokenType.AND;
+            case "class" -> TokenType.CLASS;
+            case "else" -> TokenType.ELSE;
+            case "false" -> TokenType.FALSE;
+            case "for" -> TokenType.FOR;
+            case "fun" -> TokenType.FUN;
+            case "if" -> TokenType.IF;
+            case "nil" -> TokenType.NIL;
+            case "or" -> TokenType.OR;
+            case "print" -> TokenType.PRINT;
+            case "return" -> TokenType.RETURN;
+            case "super" -> TokenType.SUPER;
+            case "this" -> TokenType.THIS;
+            case "true" -> TokenType.TRUE;
+            case "var" -> TokenType.VAR;
+            case "while" -> TokenType.WHILE;
+            default -> TokenType.IDENTIFIER;
+        };
+        return new ExplicitToken(type, lexeme, this.source.position());
+    }
+
+    /**
+     * Determines whether a character is valid within an identifier.
+     *
+     * @param c The character to check
+     * @return True if the character is alphanumeric or underscore
+     */
+    private boolean isAlphaNumeric(final char c) {
+        return c == '_'
+                || (c >= 'a' && c <= 'z')
+                || (c >= 'A' && c <= 'Z')
+                || (c >= '0' && c <= '9');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public LexingResult collectResult() {
+        return this.result;
+    }
+}

--- a/src/main/java/com/andreychh/lox/lexing/state/InitialState.java
+++ b/src/main/java/com/andreychh/lox/lexing/state/InitialState.java
@@ -58,6 +58,12 @@ public final class InitialState implements LexingState {
             case '/' -> new SlashState(this.source, this.result);
             case '"' -> new StringState(this.source, this.result);
             case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9' -> new NumberState(this.source, this.result);
+            case '_', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i',
+                 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's',
+                 't', 'u', 'v', 'w', 'x', 'y', 'z', 'A', 'B', 'C',
+                 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+                 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W',
+                 'X', 'Y', 'Z' -> new IdentifierState(this.source, this.result);
             default -> {
                 Error error = new Error("Unexpected character '%s'.".formatted(character), this.source.position());
                 yield new InitialState(this.source.skip(1), this.result.withError(error));

--- a/src/main/java/com/andreychh/lox/lexing/state/NumberState.java
+++ b/src/main/java/com/andreychh/lox/lexing/state/NumberState.java
@@ -14,15 +14,15 @@ import com.andreychh.lox.token.TokenType;
  * {@snippet :
  * // Creates a number token for "123"
  * NumberState state = new NumberState(new Source("123"), new LexingResult());
- * LexingStep step = state.next(); // Returns number token
+ * LexingStep step = state.next(); // Returns NUMBER token
  *
  * // Creates a number token for "123.45"
  * NumberState decimalState = new NumberState(new Source("123.45"), new LexingResult());
- * LexingStep decimalStep = decimalState.next(); // Returns number token
+ * LexingStep decimalStep = decimalState.next(); // Returns NUMBER token
  *
  * // Creates a number token for "42.0"
  * NumberState zeroDecimalState = new NumberState(new Source("42.0"), new LexingResult());
- * LexingStep zeroStep = zeroDecimalState.next(); // Returns number token
+ * LexingStep zeroStep = zeroDecimalState.next(); // Returns NUMBER token
  *}
  */
 public final class NumberState implements LexingState {

--- a/src/main/java/com/andreychh/lox/lexing/state/SlashState.java
+++ b/src/main/java/com/andreychh/lox/lexing/state/SlashState.java
@@ -11,9 +11,9 @@ import com.andreychh.lox.token.TokenFromLexeme;
  * This state is entered when a '/' character is encountered in the source code.
  * <p>
  * {@snippet :
- * // Creates a division token for "/"
+ * // Creates a slash token for "/"
  * SlashState state = new SlashState(new Source("/"), new LexingResult());
- * LexingStep step = state.next(); // Returns division token
+ * LexingStep step = state.next(); // Returns SLASH token
  *
  * // Skips line comment for "//"
  * SlashState commentState = new SlashState(new Source("//comment"), new LexingResult());

--- a/src/main/java/com/andreychh/lox/lexing/state/StringState.java
+++ b/src/main/java/com/andreychh/lox/lexing/state/StringState.java
@@ -14,9 +14,9 @@ import com.andreychh.lox.token.TokenType;
  * This state is entered when a '"' character is encountered in the source code.
  * <p>
  * {@snippet :
- * // Creates a string token for "\"hello\""
+ * // Creates a string token for "hello"
  * StringState state = new StringState(new Source("\"hello\""), new LexingResult());
- * LexingStep step = state.next(); // Returns string token
+ * LexingStep step = state.next(); // Returns STRING token
  *
  * // Handles unterminated string
  * StringState unterminatedState = new StringState(new Source("\"hello"), new LexingResult());

--- a/src/test/java/com/andreychh/lox/lexing/state/IdentifierStateTest.java
+++ b/src/test/java/com/andreychh/lox/lexing/state/IdentifierStateTest.java
@@ -6,6 +6,11 @@ import com.andreychh.lox.lexing.LexingResult;
 import com.andreychh.lox.token.ExplicitToken;
 import com.andreychh.lox.token.TokenType;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -13,18 +18,19 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * Tests for {@link IdentifierState}.
  */
 class IdentifierStateTest {
-    @Test
-    void recognizesVarKeyword() {
+    @ParameterizedTest
+    @MethodSource("keywordToTokenType")
+    void recognizesKeyword(String keyword, TokenType type) {
         assertEquals(
-                new ExplicitToken(TokenType.VAR, "var", new Position(1, 1)),
-                new IdentifierState(new Source("var"), new LexingResult())
+                new ExplicitToken(type, keyword, new Position(1, 1)),
+                new IdentifierState(new Source(keyword), new LexingResult())
                         .next()
                         .state()
                         .collectResult()
                         .tokens()
                         .iterator()
                         .next(),
-                "IdentifierState failed to recognize 'var' as a keyword token"
+                "IdentifierState failed to recognize '%s' as %s token".formatted(keyword, type)
         );
     }
 
@@ -115,6 +121,27 @@ class IdentifierStateTest {
                         .iterator()
                         .next(),
                 "IdentifierState incorrectly recognized capitalized 'Variable' as keyword instead of identifier"
+        );
+    }
+
+    private static Stream<Arguments> keywordToTokenType() {
+        return Stream.of(
+                Arguments.of("and", TokenType.AND),
+                Arguments.of("class", TokenType.CLASS),
+                Arguments.of("else", TokenType.ELSE),
+                Arguments.of("false", TokenType.FALSE),
+                Arguments.of("for", TokenType.FOR),
+                Arguments.of("fun", TokenType.FUN),
+                Arguments.of("if", TokenType.IF),
+                Arguments.of("nil", TokenType.NIL),
+                Arguments.of("or", TokenType.OR),
+                Arguments.of("print", TokenType.PRINT),
+                Arguments.of("return", TokenType.RETURN),
+                Arguments.of("super", TokenType.SUPER),
+                Arguments.of("this", TokenType.THIS),
+                Arguments.of("true", TokenType.TRUE),
+                Arguments.of("var", TokenType.VAR),
+                Arguments.of("while", TokenType.WHILE)
         );
     }
 }

--- a/src/test/java/com/andreychh/lox/lexing/state/IdentifierStateTest.java
+++ b/src/test/java/com/andreychh/lox/lexing/state/IdentifierStateTest.java
@@ -1,0 +1,120 @@
+package com.andreychh.lox.lexing.state;
+
+import com.andreychh.lox.Position;
+import com.andreychh.lox.Source;
+import com.andreychh.lox.lexing.LexingResult;
+import com.andreychh.lox.token.ExplicitToken;
+import com.andreychh.lox.token.TokenType;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests for {@link IdentifierState}.
+ */
+class IdentifierStateTest {
+    @Test
+    void recognizesVarKeyword() {
+        assertEquals(
+                new ExplicitToken(TokenType.VAR, "var", new Position(1, 1)),
+                new IdentifierState(new Source("var"), new LexingResult())
+                        .next()
+                        .state()
+                        .collectResult()
+                        .tokens()
+                        .iterator()
+                        .next(),
+                "IdentifierState failed to recognize 'var' as a keyword token"
+        );
+    }
+
+    @Test
+    void stopsAtNonAlphanumericCharacter() {
+        assertEquals(
+                new ExplicitToken(TokenType.VAR, "var", new Position(1, 1)),
+                new IdentifierState(new Source("var("), new LexingResult())
+                        .next()
+                        .state()
+                        .collectResult()
+                        .tokens()
+                        .iterator()
+                        .next(),
+                "IdentifierState failed to stop parsing at non-alphanumeric character"
+        );
+    }
+
+    @Test
+    void createsIdentifierWithNumbers() {
+        assertEquals(
+                new ExplicitToken(TokenType.IDENTIFIER, "var123", new Position(1, 1)),
+                new IdentifierState(new Source("var123"), new LexingResult())
+                        .next()
+                        .state()
+                        .collectResult()
+                        .tokens()
+                        .iterator()
+                        .next(),
+                "IdentifierState failed to create identifier token containing numbers"
+        );
+    }
+
+    @Test
+    void createsIdentifierStartingWithUnderscore() {
+        assertEquals(
+                new ExplicitToken(TokenType.IDENTIFIER, "_var", new Position(1, 1)),
+                new IdentifierState(new Source("_var"), new LexingResult())
+                        .next()
+                        .state()
+                        .collectResult()
+                        .tokens()
+                        .iterator()
+                        .next(),
+                "IdentifierState failed to create identifier token starting with underscore"
+        );
+    }
+
+    @Test
+    void createsSingleLetterIdentifier() {
+        assertEquals(
+                new ExplicitToken(TokenType.IDENTIFIER, "a", new Position(1, 1)),
+                new IdentifierState(new Source("a"), new LexingResult())
+                        .next()
+                        .state()
+                        .collectResult()
+                        .tokens()
+                        .iterator()
+                        .next(),
+                "IdentifierState failed to create single-letter identifier token"
+        );
+    }
+
+    @Test
+    void treatsUppercaseKeywordAsIdentifier() {
+        assertEquals(
+                new ExplicitToken(TokenType.IDENTIFIER, "VAR", new Position(1, 1)),
+                new IdentifierState(new Source("VAR"), new LexingResult())
+                        .next()
+                        .state()
+                        .collectResult()
+                        .tokens()
+                        .iterator()
+                        .next(),
+                "IdentifierState incorrectly recognized uppercase 'VAR' as keyword instead of identifier"
+        );
+    }
+
+    @Test
+    void treatsCapitalizedWordAsIdentifier() {
+        assertEquals(
+                new ExplicitToken(TokenType.IDENTIFIER, "Variable", new Position(1, 1)),
+                new IdentifierState(new Source("Variable"), new LexingResult())
+                        .next()
+                        .state()
+                        .collectResult()
+                        .tokens()
+                        .iterator()
+                        .next(),
+                "IdentifierState incorrectly recognized capitalized 'Variable' as keyword instead of identifier"
+        );
+    }
+}


### PR DESCRIPTION
This pull request introduces a new lexing state for handling identifiers and keywords in the lexer, updates the main lexing state to use it, and adds tests for identifier lexing.

Closes #14 