### PR TITLE
Add `Expression` and `Operation` interfaces

### DIFF
--- a/src/main/java/com/andreychh/lox/parsing/expression/BinaryExpression.java
+++ b/src/main/java/com/andreychh/lox/parsing/expression/BinaryExpression.java
@@ -1,0 +1,40 @@
+package com.andreychh.lox.parsing.expression;
+
+import com.andreychh.lox.parsing.operation.Operation;
+import com.andreychh.lox.token.Token;
+
+/**
+ * Represents a binary operation expression in the Lox language.
+ * <p>
+ * A binary expression consists of a left and right operand and an operator token.
+ */
+public final class BinaryExpression implements Expression {
+    private final Token operator;
+    private final Expression left;
+    private final Expression right;
+
+    /**
+     * Constructs a binary expression with the given operator and operands.
+     *
+     * @param operator the operator token
+     * @param left     the left operand
+     * @param right    the right operand
+     */
+    public BinaryExpression(final Token operator, final Expression left, final Expression right) {
+        this.operator = operator;
+        this.left = left;
+        this.right = right;
+    }
+
+    /**
+     * Applies the given operation to this binary expression.
+     *
+     * @param operation the operation to apply
+     * @param <T>       the result type of the operation
+     * @return the result of applying the operation
+     */
+    @Override
+    public <T> T perform(final Operation<T> operation) {
+        return operation.applyToBinary(this.operator, this.left, this.right);
+    }
+}

--- a/src/main/java/com/andreychh/lox/parsing/expression/Expression.java
+++ b/src/main/java/com/andreychh/lox/parsing/expression/Expression.java
@@ -1,0 +1,17 @@
+package com.andreychh.lox.parsing.expression;
+
+import com.andreychh.lox.parsing.operation.Operation;
+
+/**
+ * Represents an abstract syntax tree node for an expression in the Lox language.
+ */
+public interface Expression {
+    /**
+     * Applies the given operation to this expression node.
+     *
+     * @param operation the operation to apply
+     * @param <T>       the result type of the operation
+     * @return the result of applying the operation
+     */
+    <T> T perform(Operation<T> operation);
+}

--- a/src/main/java/com/andreychh/lox/parsing/expression/GroupingExpression.java
+++ b/src/main/java/com/andreychh/lox/parsing/expression/GroupingExpression.java
@@ -1,0 +1,33 @@
+package com.andreychh.lox.parsing.expression;
+
+import com.andreychh.lox.parsing.operation.Operation;
+
+/**
+ * Represents a grouping expression in the Lox language.
+ * <p>
+ * A grouping expression wraps another expression in parentheses to override precedence.
+ */
+public final class GroupingExpression implements Expression {
+    private final Expression grouped;
+
+    /**
+     * Constructs a grouping expression with the given inner expression.
+     *
+     * @param grouped the inner expression to group
+     */
+    public GroupingExpression(final Expression grouped) {
+        this.grouped = grouped;
+    }
+
+    /**
+     * Applies the given operation to this grouping expression.
+     *
+     * @param operation the operation to apply
+     * @param <T>       the result type of the operation
+     * @return the result of applying the operation
+     */
+    @Override
+    public <T> T perform(final Operation<T> operation) {
+        return operation.applyToGrouping(this.grouped);
+    }
+}

--- a/src/main/java/com/andreychh/lox/parsing/expression/LiteralExpression.java
+++ b/src/main/java/com/andreychh/lox/parsing/expression/LiteralExpression.java
@@ -1,0 +1,34 @@
+package com.andreychh.lox.parsing.expression;
+
+import com.andreychh.lox.parsing.operation.Operation;
+import com.andreychh.lox.token.Token;
+
+/**
+ * Represents a literal value expression in the Lox language.
+ * <p>
+ * A literal expression holds a token representing a value such as a number, string, or boolean.
+ */
+public final class LiteralExpression implements Expression {
+    private final Token literal;
+
+    /**
+     * Constructs a literal expression with the given token.
+     *
+     * @param literal the literal token
+     */
+    public LiteralExpression(final Token literal) {
+        this.literal = literal;
+    }
+
+    /**
+     * Applies the given operation to this literal expression.
+     *
+     * @param operation the operation to apply
+     * @param <T>       the result type of the operation
+     * @return the result of applying the operation
+     */
+    @Override
+    public <T> T perform(final Operation<T> operation) {
+        return operation.applyToLiteral(this.literal);
+    }
+}

--- a/src/main/java/com/andreychh/lox/parsing/expression/UnaryExpression.java
+++ b/src/main/java/com/andreychh/lox/parsing/expression/UnaryExpression.java
@@ -1,0 +1,37 @@
+package com.andreychh.lox.parsing.expression;
+
+import com.andreychh.lox.parsing.operation.Operation;
+import com.andreychh.lox.token.Token;
+
+/**
+ * Represents a unary operation expression in the Lox language.
+ * <p>
+ * A unary expression consists of an operator token and a single operand.
+ */
+public final class UnaryExpression implements Expression {
+    private final Token operator;
+    private final Expression operand;
+
+    /**
+     * Constructs a unary expression with the given operator and operand.
+     *
+     * @param operator the operator token
+     * @param operand  the operand expression
+     */
+    public UnaryExpression(Token operator, Expression operand) {
+        this.operator = operator;
+        this.operand = operand;
+    }
+
+    /**
+     * Applies the given operation to this unary expression.
+     *
+     * @param operation the operation to apply
+     * @param <T>       the result type of the operation
+     * @return the result of applying the operation
+     */
+    @Override
+    public <T> T perform(final Operation<T> operation) {
+        return operation.applyToUnary(this.operator, this.operand);
+    }
+}

--- a/src/main/java/com/andreychh/lox/parsing/expression/UnaryExpression.java
+++ b/src/main/java/com/andreychh/lox/parsing/expression/UnaryExpression.java
@@ -18,7 +18,7 @@ public final class UnaryExpression implements Expression {
      * @param operator the operator token
      * @param operand  the operand expression
      */
-    public UnaryExpression(Token operator, Expression operand) {
+    public UnaryExpression(final Token operator, final Expression operand) {
         this.operator = operator;
         this.operand = operand;
     }

--- a/src/main/java/com/andreychh/lox/parsing/operation/Operation.java
+++ b/src/main/java/com/andreychh/lox/parsing/operation/Operation.java
@@ -1,6 +1,6 @@
 package com.andreychh.lox.parsing.operation;
 
-import com.andreychh.lox.parsing.expression.*;
+import com.andreychh.lox.parsing.expression.Expression;
 import com.andreychh.lox.token.Token;
 
 /**

--- a/src/main/java/com/andreychh/lox/parsing/operation/Operation.java
+++ b/src/main/java/com/andreychh/lox/parsing/operation/Operation.java
@@ -1,0 +1,48 @@
+package com.andreychh.lox.parsing.operation;
+
+import com.andreychh.lox.parsing.expression.*;
+import com.andreychh.lox.token.Token;
+
+/**
+ * Represents an operation that can be performed on expression nodes in the Lox abstract syntax tree.
+ * <p>
+ * Implementations of this interface define how to process each kind of expression node.
+ *
+ * @param <T> the result type of the operation
+ */
+public interface Operation<T> {
+    /**
+     * Applies this operation to a binary expression node.
+     *
+     * @param operator the operator token
+     * @param left     the left operand expression
+     * @param right    the right operand expression
+     * @return the result of the operation
+     */
+    T applyToBinary(Token operator, Expression left, Expression right);
+
+    /**
+     * Applies this operation to a grouping expression node.
+     *
+     * @param grouped the grouped expression
+     * @return the result of the operation
+     */
+    T applyToGrouping(Expression grouped);
+
+    /**
+     * Applies this operation to a literal expression node.
+     *
+     * @param literal the literal token
+     * @return the result of the operation
+     */
+    T applyToLiteral(Token literal);
+
+    /**
+     * Applies this operation to a unary expression node.
+     *
+     * @param operator the operator token
+     * @param operand  the operand expression
+     * @return the result of the operation
+     */
+    T applyToUnary(Token operator, Expression operand);
+}

--- a/src/main/java/com/andreychh/lox/parsing/operation/PrintOperation.java
+++ b/src/main/java/com/andreychh/lox/parsing/operation/PrintOperation.java
@@ -1,0 +1,51 @@
+package com.andreychh.lox.parsing.operation;
+
+import com.andreychh.lox.parsing.expression.Expression;
+import com.andreychh.lox.token.Token;
+
+/**
+ * Implements the {@link Operation} interface to produce a string representation of Lox expressions.
+ * <p>
+ * This operation traverses the expression tree and formats each node as a string.
+ */
+public final class PrintOperation implements Operation<String> {
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Formats a binary expression as {@code (operator left right)}.
+     */
+    @Override
+    public String applyToBinary(final Token operator, final Expression left, final Expression right) {
+        return "(%s %s %s)".formatted(operator.format(), left.perform(this), right.perform(this));
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Formats a grouping expression as {@code (grouped)}.
+     */
+    @Override
+    public String applyToGrouping(final Expression grouped) {
+        return "(%s)".formatted(grouped.perform(this));
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Formats a literal expression using the token's format.
+     */
+    @Override
+    public String applyToLiteral(final Token literal) {
+        return literal.format();
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Formats a unary expression as {@code (operator operand)}.
+     */
+    @Override
+    public String applyToUnary(final Token operator, final Expression operand) {
+        return "(%s %s)".formatted(operator.format(), operand.perform(this));
+    }
+}


### PR DESCRIPTION
This pull request introduces a new expression AST (Abstract Syntax Tree) structure for the Lox language, implementing the Visitor pattern to enable operations on a different expression. The changes define `Expression` interface and concrete classes for various expression nodes (binary, grouping, literal, unary), an `Operation` interface for processing expressions, and a sample implementation that prints expressions as strings.

Closes #23 